### PR TITLE
Add dark theme for MDXEditor

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@mdxeditor/editor": "^3.37.0",
+        "@radix-ui/colors": "^3.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@mdxeditor/editor": "^3.37.0",
+    "@radix-ui/colors": "^3.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/ui/src/ModForm.tsx
+++ b/ui/src/ModForm.tsx
@@ -226,6 +226,7 @@ export default function ModForm({ onSubmit, initial }: Props) {
               onChange={(e) => updatePage(i, 'level', parseInt(e.target.value))}
             />
             <MDXEditor
+              className="dark-editor"
               markdown={p.content}
               onChange={(v) => updatePage(i, 'content', v)}
               plugins={[

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,3 +1,5 @@
+@import "./mdxeditor-dark.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/ui/src/mdxeditor-dark.css
+++ b/ui/src/mdxeditor-dark.css
@@ -1,0 +1,50 @@
+@import url('@radix-ui/colors/indigo-dark.css');
+@import url('@radix-ui/colors/slate-dark.css');
+
+.dark-editor {
+  --accentBase: var(--indigo-1);
+  --accentBgSubtle: var(--indigo-2);
+  --accentBg: var(--indigo-3);
+  --accentBgHover: var(--indigo-4);
+  --accentBgActive: var(--indigo-5);
+  --accentLine: var(--indigo-6);
+  --accentBorder: var(--indigo-7);
+  --accentBorderHover: var(--indigo-8);
+  --accentSolid: var(--indigo-9);
+  --accentSolidHover: var(--indigo-10);
+  --accentText: var(--indigo-11);
+  --accentTextContrast: var(--indigo-12);
+
+  --baseBase: var(--slate-1);
+  --baseBgSubtle: var(--slate-2);
+  --baseBg: var(--slate-3);
+  --baseBgHover: var(--slate-4);
+  --baseBgActive: var(--slate-5);
+  --baseLine: var(--slate-6);
+  --baseBorder: var(--slate-7);
+  --baseBorderHover: var(--slate-8);
+  --baseSolid: var(--slate-9);
+  --baseSolidHover: var(--slate-10);
+  --baseText: var(--slate-11);
+  --baseTextContrast: var(--slate-12);
+
+  --admonitionTipBg: var(--cyan-4);
+  --admonitionTipBorder: var(--cyan-8);
+  --admonitionInfoBg: var(--grass-4);
+  --admonitionInfoBorder: var(--grass-8);
+  --admonitionCautionBg: var(--amber-4);
+  --admonitionCautionBorder: var(--amber-8);
+  --admonitionDangerBg: var(--red-4);
+  --admonitionDangerBorder: var(--red-8);
+  --admonitionNoteBg: var(--slate-4);
+  --admonitionNoteBorder: var(--slate-8);
+
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+
+  color: var(--baseText);
+  --basePageBg: #000;
+  background: var(--basePageBg);
+}


### PR DESCRIPTION
## Summary
- add `@radix-ui/colors` and a new `mdxeditor-dark.css` file defining dark theme variables
- import the dark theme CSS in index.css
- apply the `dark-editor` class to MDXEditor so it uses the new styles

## Testing
- `npm --prefix ui run lint`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_e_685921d39f0883318276f607e654fec2