### PR TITLE
Add layout component and style updates

### DIFF
--- a/ui/src/Layout.tsx
+++ b/ui/src/Layout.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react';
+
+export default function Layout({ children }: PropsWithChildren) {
+  return <div className="max-w-6xl mx-auto p-4">{children}</div>;
+}

--- a/ui/src/ModForm.tsx
+++ b/ui/src/ModForm.tsx
@@ -108,8 +108,8 @@ export default function ModForm({ onSubmit, initial }: Props) {
           }
         />
       </div>
-      <fieldset className="border border-base-300 p-4 rounded-box">
-        <legend className="font-bold">Ids</legend>
+      <fieldset className="fieldset p-4 rounded-box border border-base-300">
+        <legend className="fieldset-legend">Ids</legend>
         <div className="form-control">
           <label className="label">
             <span className="label-text">Modrinth</span>
@@ -131,8 +131,8 @@ export default function ModForm({ onSubmit, initial }: Props) {
           />
         </div>
       </fieldset>
-      <fieldset className="border border-base-300 p-4 rounded-box">
-        <legend className="font-bold">Urls</legend>
+      <fieldset className="fieldset p-4 rounded-box border border-base-300">
+        <legend className="fieldset-legend">Urls</legend>
         {(['modrinth', 'curseforge', 'source', 'issues', 'support', 'discord'] as const).map((key) => {
           const val = (mod.urls as any)?.[key] ?? '';
           return (
@@ -154,8 +154,8 @@ export default function ModForm({ onSubmit, initial }: Props) {
           );
         })}
       </fieldset>
-      <fieldset className="space-y-2 border border-base-300 p-4 rounded-box">
-        <legend className="font-bold flex justify-between items-center">
+      <fieldset className="fieldset p-4 rounded-box border border-base-300 space-y-2">
+        <legend className="fieldset-legend flex justify-between items-center">
           <span>Dependencies</span>
           <button type="button" className="btn btn-xs" onClick={addDep}>
             <PlusIcon className="w-4 h-4" />
@@ -203,8 +203,8 @@ export default function ModForm({ onSubmit, initial }: Props) {
           </div>
         ))}
       </fieldset>
-      <fieldset className="space-y-2 border border-base-300 p-4 rounded-box">
-        <legend className="font-bold flex justify-between items-center">
+      <fieldset className="fieldset p-4 rounded-box border border-base-300 space-y-2">
+        <legend className="fieldset-legend flex justify-between items-center">
           <span>Pages</span>
           <button type="button" className="btn btn-xs" onClick={addPage}>
             <PlusIcon className="w-4 h-4" />

--- a/ui/src/pages/Icon.tsx
+++ b/ui/src/pages/Icon.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Icon() {
-  return <div className="p-4">icon page</div>;
+  return <Layout>icon page</Layout>;
 }

--- a/ui/src/pages/Images.tsx
+++ b/ui/src/pages/Images.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Images() {
-  return <div className="p-4">images page</div>;
+  return <Layout>images page</Layout>;
 }

--- a/ui/src/pages/Mods.tsx
+++ b/ui/src/pages/Mods.tsx
@@ -3,6 +3,7 @@ import { PencilSquareIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import ModForm from '../ModForm';
 import type { ModEntry } from '../../../lib/readMods';
 import { listMods, addMod, updateMod } from '../api';
+import Layout from '../Layout';
 
 export default function Mods() {
   const [mods, setMods] = useState<ModEntry[]>([]);
@@ -15,12 +16,13 @@ export default function Mods() {
 
   return (
     <>
-      <div className="max-w-6xl mx-auto p-4 flex gap-6">
-        <div className="space-y-4 min-w-60">
-          <h1 className="text-3xl font-bold text-primary">Mods</h1>
-          <ul className="space-y-2">
-            {mods.map((m) => (
-              <li key={m.id} className="flex justify-between items-center p-2 rounded-box bg-base-200">
+      <Layout>
+        <div className="flex gap-6">
+          <div className="space-y-4 min-w-60">
+            <h1 className="text-3xl font-bold text-primary">Mods</h1>
+            <ul className="space-y-2">
+              {mods.map((m) => (
+                <li key={m.id} className="flex justify-between items-center p-2 rounded-box bg-base-200">
                 <span>{m.name}</span>
                 <button className="btn btn-accent btn-sm" onClick={() => setEditing(m)}>
                   <PencilSquareIcon className="w-4 h-4" />
@@ -53,6 +55,7 @@ export default function Mods() {
           )}
         </div>
       </div>
+      </Layout>
       {message && (
         <div className="toast toast-top toast-end">
           <div className="alert alert-success">{message}</div>

--- a/ui/src/pages/Othermods.tsx
+++ b/ui/src/pages/Othermods.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Othermods() {
-  return <div className="p-4">othermods page</div>;
+  return <Layout>othermods page</Layout>;
 }

--- a/ui/src/pages/Pad.tsx
+++ b/ui/src/pages/Pad.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Pad() {
-  return <div className="p-4">pad page</div>;
+  return <Layout>pad page</Layout>;
 }

--- a/ui/src/pages/Pagesv2.tsx
+++ b/ui/src/pages/Pagesv2.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Pagesv2() {
-  return <div className="p-4">pagesv2 page</div>;
+  return <Layout>pagesv2 page</Layout>;
 }

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Upload() {
-  return <div className="p-4">upload page</div>;
+  return <Layout>upload page</Layout>;
 }

--- a/ui/src/pages/Validate.tsx
+++ b/ui/src/pages/Validate.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Validate() {
-  return <div className="p-4">validate page</div>;
+  return <Layout>validate page</Layout>;
 }


### PR DESCRIPTION
## Summary
- create a `Layout` wrapper for shared page structure
- use layout on every page
- tweak `ModForm` fieldsets to use daisyUI classes

## Testing
- `npm run lint` in `ui`

------
https://chatgpt.com/codex/tasks/task_e_685947af66b08331bfa3d17a77ae8e35