### PR TITLE
Add shared layout and DaisyUI fieldsets

### DIFF
--- a/ui/src/Layout.tsx
+++ b/ui/src/Layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  children: ReactNode;
+}
+
+export default function Layout({ title, children }: Props) {
+  return (
+    <div className="max-w-6xl mx-auto p-4 space-y-4">
+      <h1 className="text-3xl font-bold text-primary capitalize">{title}</h1>
+      {children}
+    </div>
+  );
+}

--- a/ui/src/ModForm.tsx
+++ b/ui/src/ModForm.tsx
@@ -108,54 +108,48 @@ export default function ModForm({ onSubmit, initial }: Props) {
           }
         />
       </div>
-      <fieldset className="border border-base-300 p-4 rounded-box">
-        <legend className="font-bold">Ids</legend>
-        <div className="form-control">
-          <label className="label">
-            <span className="label-text">Modrinth</span>
-          </label>
+      <fieldset className="fieldset border border-base-300 p-4 rounded-box">
+        <legend className="fieldset-legend font-bold">Ids</legend>
+        <label className="form-control fieldset-label">
+          <span className="label-text">Modrinth</span>
           <input
             className="input input-bordered"
             value={mod.ids?.modrinth ?? ''}
             onChange={(e) => update('ids', { ...mod.ids, modrinth: e.target.value })}
           />
-        </div>
-        <div className="form-control">
-          <label className="label">
-            <span className="label-text">CurseForge</span>
-          </label>
+        </label>
+        <label className="form-control fieldset-label">
+          <span className="label-text">CurseForge</span>
           <input
             className="input input-bordered"
             value={mod.ids?.curseforge ?? ''}
             onChange={(e) => update('ids', { ...mod.ids, curseforge: e.target.value })}
           />
-        </div>
+        </label>
       </fieldset>
-      <fieldset className="border border-base-300 p-4 rounded-box">
-        <legend className="font-bold">Urls</legend>
+      <fieldset className="fieldset border border-base-300 p-4 rounded-box">
+        <legend className="fieldset-legend font-bold">Urls</legend>
         {(['modrinth', 'curseforge', 'source', 'issues', 'support', 'discord'] as const).map((key) => {
           const val = (mod.urls as any)?.[key] ?? '';
           return (
-            <div key={key} className="form-control">
-              <label className="label justify-between">
-                <span className="label-text capitalize">{key}</span>
-                {val && (
-                  <button type="button" className="btn btn-xs btn-secondary" onClick={() => window.open(val, '_blank')}>
-                    <ArrowTopRightOnSquareIcon className="w-4 h-4" />
-                  </button>
-                )}
-              </label>
+            <label key={key} className="form-control fieldset-label">
+              <span className="label-text capitalize">{key}</span>
+              {val && (
+                <button type="button" className="btn btn-xs btn-secondary" onClick={() => window.open(val, '_blank')}>
+                  <ArrowTopRightOnSquareIcon className="w-4 h-4" />
+                </button>
+              )}
               <input
                 className="input input-bordered"
                 value={val}
                 onChange={(e) => update('urls', { ...mod.urls, [key]: e.target.value })}
               />
-            </div>
+            </label>
           );
         })}
       </fieldset>
-      <fieldset className="space-y-2 border border-base-300 p-4 rounded-box">
-        <legend className="font-bold flex justify-between items-center">
+      <fieldset className="fieldset space-y-2 border border-base-300 p-4 rounded-box">
+        <legend className="fieldset-legend font-bold flex justify-between items-center">
           <span>Dependencies</span>
           <button type="button" className="btn btn-xs" onClick={addDep}>
             <PlusIcon className="w-4 h-4" />
@@ -203,8 +197,8 @@ export default function ModForm({ onSubmit, initial }: Props) {
           </div>
         ))}
       </fieldset>
-      <fieldset className="space-y-2 border border-base-300 p-4 rounded-box">
-        <legend className="font-bold flex justify-between items-center">
+      <fieldset className="fieldset space-y-2 border border-base-300 p-4 rounded-box">
+        <legend className="fieldset-legend font-bold flex justify-between items-center">
           <span>Pages</span>
           <button type="button" className="btn btn-xs" onClick={addPage}>
             <PlusIcon className="w-4 h-4" />

--- a/ui/src/pages/Icon.tsx
+++ b/ui/src/pages/Icon.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Icon() {
-  return <div className="p-4">icon page</div>;
+  return <Layout title="Icon">icon page</Layout>;
 }

--- a/ui/src/pages/Images.tsx
+++ b/ui/src/pages/Images.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Images() {
-  return <div className="p-4">images page</div>;
+  return <Layout title="Images">images page</Layout>;
 }

--- a/ui/src/pages/Mods.tsx
+++ b/ui/src/pages/Mods.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { PencilSquareIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import ModForm from '../ModForm';
+import Layout from '../Layout';
 import type { ModEntry } from '../../../lib/readMods';
 import { listMods, addMod, updateMod } from '../api';
 
@@ -14,10 +15,9 @@ export default function Mods() {
   }, []);
 
   return (
-    <>
-      <div className="max-w-6xl mx-auto p-4 flex gap-6">
+    <Layout title="Mods">
+      <div className="flex gap-6">
         <div className="space-y-4 min-w-60">
-          <h1 className="text-3xl font-bold text-primary">Mods</h1>
           <ul className="space-y-2">
             {mods.map((m) => (
               <li key={m.id} className="flex justify-between items-center p-2 rounded-box bg-base-200">
@@ -58,6 +58,6 @@ export default function Mods() {
           <div className="alert alert-success">{message}</div>
         </div>
       )}
-    </>
+    </Layout>
   );
 }

--- a/ui/src/pages/Othermods.tsx
+++ b/ui/src/pages/Othermods.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Othermods() {
-  return <div className="p-4">othermods page</div>;
+  return <Layout title="Othermods">othermods page</Layout>;
 }

--- a/ui/src/pages/Pad.tsx
+++ b/ui/src/pages/Pad.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Pad() {
-  return <div className="p-4">pad page</div>;
+  return <Layout title="Pad">pad page</Layout>;
 }

--- a/ui/src/pages/Pagesv2.tsx
+++ b/ui/src/pages/Pagesv2.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Pagesv2() {
-  return <div className="p-4">pagesv2 page</div>;
+  return <Layout title="Pagesv2">pagesv2 page</Layout>;
 }

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Upload() {
-  return <div className="p-4">upload page</div>;
+  return <Layout title="Upload">upload page</Layout>;
 }

--- a/ui/src/pages/Validate.tsx
+++ b/ui/src/pages/Validate.tsx
@@ -1,3 +1,5 @@
+import Layout from '../Layout';
+
 export default function Validate() {
-  return <div className="p-4">validate page</div>;
+  return <Layout title="Validate">validate page</Layout>;
 }


### PR DESCRIPTION
## Summary
- add `Layout` wrapper for consistent spacing and page titles
- apply DaisyUI `fieldset` styling in `ModForm`
- wrap all pages with the new layout

## Testing
- `npm --prefix ui run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685947af66b08331bfa3d17a77ae8e35