### PR TITLE
Implement UI pages using backend tools

### DIFF
--- a/ui/server.ts
+++ b/ui/server.ts
@@ -1,12 +1,25 @@
 import express from 'express';
 import cors from 'cors';
 import { ModManager } from '../src/ModManager';
+import { exec } from 'child_process';
+import path from 'path';
+import fs from 'fs';
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
 const manager = new ModManager();
+
+function runScript(script: string, args: string[] = []): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const cmd = `npx tsx ${path.join('tools', script)}`;
+    exec(`${cmd} ${args.join(' ')}`, { cwd: path.join(__dirname, '..') }, (err, stdout, stderr) => {
+      if (err) return reject(stderr || err.message);
+      resolve(stdout || '');
+    });
+  });
+}
 
 app.get('/api/mods', (_req, res) => {
   res.json(manager.list());
@@ -42,6 +55,89 @@ app.delete('/api/mods/:id', (req, res) => {
     res.sendStatus(204);
   } catch (err: any) {
     res.status(400).json({ error: err.message });
+  }
+});
+
+app.get('/api/images', async (req, res) => {
+  try {
+    const mod = (req.query.mod as string) || undefined;
+    const pagesDir = path.join(__dirname, '..', 'pages');
+    const mods = mod ? [mod] : fs.readdirSync(pagesDir);
+    const result: Record<string, string[]> = {};
+    for (const m of mods) {
+      const modPath = path.join(pagesDir, m);
+      if (!fs.existsSync(modPath) || !fs.statSync(modPath).isDirectory()) continue;
+      const images = fs.readdirSync(modPath).filter((f) => f.endsWith('.png'));
+      if (images.length) {
+        result[m] = images.map((img) =>
+          `https://raw.githubusercontent.com/iamkaf/modresources/refs/heads/main/pages/${m}/${img}`,
+        );
+      }
+    }
+    res.json(result);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/pad', async (_req, res) => {
+  try {
+    const file = path.join(__dirname, '..', 'tools', 'scratchpad.md');
+    const content = fs.readFileSync(file, 'utf-8');
+    const sanitized = content
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '');
+    res.json({ text: sanitized });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/pagesv2', async (_req, res) => {
+  try {
+    await runScript('page-builder.v2.ts');
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: err });
+  }
+});
+
+app.post('/api/icon', async (_req, res) => {
+  try {
+    await runScript('icon-generator.ts');
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: err });
+  }
+});
+
+app.post('/api/upload/:id', async (req, res) => {
+  const id = req.params.id;
+  try {
+    const out = await runScript('page-uploader.ts', [id]);
+    res.type('text').send(out);
+  } catch (err: any) {
+    res.status(500).json({ error: err });
+  }
+});
+
+app.post('/api/validate', async (_req, res) => {
+  try {
+    const out = await runScript('validate-mods.ts');
+    res.type('text').send(out);
+  } catch (err: any) {
+    res.status(500).json({ error: err });
+  }
+});
+
+app.post('/api/othermods', async (_req, res) => {
+  try {
+    await runScript('other-mods.ts');
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: err });
   }
 });
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -33,3 +33,37 @@ export async function deleteMod(id: string): Promise<void> {
   await fetch(`${BASE}/mods/${id}`, { method: 'DELETE' });
 }
 
+export async function generatePagesV2(): Promise<void> {
+  await fetch(`${BASE}/pagesv2`, { method: 'POST' });
+}
+
+export async function generateIcons(): Promise<void> {
+  await fetch(`${BASE}/icon`, { method: 'POST' });
+}
+
+export async function uploadPage(id: string): Promise<string> {
+  const res = await fetch(`${BASE}/upload/${id}`, { method: 'POST' });
+  return res.text();
+}
+
+export async function validateMods(): Promise<string> {
+  const res = await fetch(`${BASE}/validate`, { method: 'POST' });
+  return res.text();
+}
+
+export async function generateOtherMods(): Promise<void> {
+  await fetch(`${BASE}/othermods`, { method: 'POST' });
+}
+
+export async function listImagesApi(mod?: string): Promise<Record<string, string[]>> {
+  const url = mod ? `${BASE}/images?mod=${encodeURIComponent(mod)}` : `${BASE}/images`;
+  const res = await fetch(url);
+  return res.json();
+}
+
+export async function readPad(): Promise<string> {
+  const res = await fetch(`${BASE}/pad`);
+  const data = await res.json();
+  return data.text;
+}
+

--- a/ui/src/pages/Icon.tsx
+++ b/ui/src/pages/Icon.tsx
@@ -1,5 +1,25 @@
+import { useState } from 'react';
 import Layout from '../Layout';
+import { generateIcons } from '../api';
 
 export default function Icon() {
-  return <Layout title="Icon">icon page</Layout>;
+  const [message, setMessage] = useState<string | null>(null);
+
+  const run = async () => {
+    try {
+      await generateIcons();
+      setMessage('Icons generated!');
+    } catch {
+      setMessage('Failed to generate icons');
+    }
+  };
+
+  return (
+    <Layout title="Icon">
+      <button className="btn btn-primary" onClick={run}>
+        Generate Icons
+      </button>
+      {message && <p>{message}</p>}
+    </Layout>
+  );
 }

--- a/ui/src/pages/Images.tsx
+++ b/ui/src/pages/Images.tsx
@@ -1,5 +1,32 @@
+import { useEffect, useState } from 'react';
 import Layout from '../Layout';
+import { listImagesApi } from '../api';
 
 export default function Images() {
-  return <Layout title="Images">images page</Layout>;
+  const [images, setImages] = useState<Record<string, string[]>>({});
+
+  useEffect(() => {
+    listImagesApi().then(setImages);
+  }, []);
+
+  return (
+    <Layout title="Images">
+      <div className="space-y-4">
+        {Object.entries(images).map(([mod, urls]) => (
+          <div key={mod}>
+            <h2 className="font-bold capitalize">{mod}</h2>
+            <ul className="list-disc ml-4">
+              {urls.map((u) => (
+                <li key={u}>
+                  <a href={u} className="link" target="_blank" rel="noreferrer">
+                    {u}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </Layout>
+  );
 }

--- a/ui/src/pages/Othermods.tsx
+++ b/ui/src/pages/Othermods.tsx
@@ -1,5 +1,25 @@
+import { useState } from 'react';
 import Layout from '../Layout';
+import { generateOtherMods } from '../api';
 
 export default function Othermods() {
-  return <Layout title="Othermods">othermods page</Layout>;
+  const [message, setMessage] = useState<string | null>(null);
+
+  const run = async () => {
+    try {
+      await generateOtherMods();
+      setMessage('Generated snippet!');
+    } catch {
+      setMessage('Failed to generate');
+    }
+  };
+
+  return (
+    <Layout title="Othermods">
+      <button className="btn btn-primary" onClick={run}>
+        Generate Promo Snippet
+      </button>
+      {message && <p>{message}</p>}
+    </Layout>
+  );
 }

--- a/ui/src/pages/Pad.tsx
+++ b/ui/src/pages/Pad.tsx
@@ -1,5 +1,17 @@
+import { useEffect, useState } from 'react';
 import Layout from '../Layout';
+import { readPad } from '../api';
 
 export default function Pad() {
-  return <Layout title="Pad">pad page</Layout>;
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    readPad().then(setText);
+  }, []);
+
+  return (
+    <Layout title="Pad">
+      <textarea className="textarea w-full h-60" value={text} readOnly />
+    </Layout>
+  );
 }

--- a/ui/src/pages/Pagesv2.tsx
+++ b/ui/src/pages/Pagesv2.tsx
@@ -1,5 +1,25 @@
+import { useState } from 'react';
 import Layout from '../Layout';
+import { generatePagesV2 } from '../api';
 
 export default function Pagesv2() {
-  return <Layout title="Pagesv2">pagesv2 page</Layout>;
+  const [message, setMessage] = useState<string | null>(null);
+
+  const run = async () => {
+    try {
+      await generatePagesV2();
+      setMessage('Pages generated!');
+    } catch {
+      setMessage('Failed to generate pages');
+    }
+  };
+
+  return (
+    <Layout title="Pagesv2">
+      <button className="btn btn-primary" onClick={run}>
+        Generate Pages
+      </button>
+      {message && <p>{message}</p>}
+    </Layout>
+  );
 }

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -1,5 +1,25 @@
+import { useState } from 'react';
 import Layout from '../Layout';
+import { uploadPage } from '../api';
 
 export default function Upload() {
-  return <Layout title="Upload">upload page</Layout>;
+  const [id, setId] = useState('');
+  const [output, setOutput] = useState('');
+
+  const run = async () => {
+    const text = await uploadPage(id);
+    setOutput(text);
+  };
+
+  return (
+    <Layout title="Upload">
+      <div className="space-y-2">
+        <input className="input" value={id} onChange={(e) => setId(e.target.value)} placeholder="Mod id" />
+        <button className="btn btn-primary" onClick={run} disabled={!id}>
+          Upload Page
+        </button>
+        {output && <pre className="whitespace-pre-wrap bg-base-200 p-2 rounded">{output}</pre>}
+      </div>
+    </Layout>
+  );
 }

--- a/ui/src/pages/Validate.tsx
+++ b/ui/src/pages/Validate.tsx
@@ -1,5 +1,21 @@
+import { useState } from 'react';
 import Layout from '../Layout';
+import { validateMods } from '../api';
 
 export default function Validate() {
-  return <Layout title="Validate">validate page</Layout>;
+  const [output, setOutput] = useState('');
+
+  const run = async () => {
+    const text = await validateMods();
+    setOutput(text);
+  };
+
+  return (
+    <Layout title="Validate">
+      <button className="btn btn-primary" onClick={run}>
+        Validate Mods
+      </button>
+      {output && <pre className="whitespace-pre-wrap bg-base-200 p-2 rounded mt-2">{output}</pre>}
+    </Layout>
+  );
 }


### PR DESCRIPTION
## Summary
- hook UI pages up to tool scripts
- add endpoints to server for image listing, page building, etc.
- expose helper methods in `api.ts`
- replace placeholders with actual logic in Icon, Images, Pad, Upload, Pagesv2, Validate and Othermods

## Testing
- `npm --prefix ui run lint`

------
https://chatgpt.com/codex/tasks/task_e_685dda401d548331a9114d328ef89c17