### PR TITLE
Expose tool scripts via API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ npm run ui
 This starts the React dev server (typically at `http://localhost:5173`) and the
 API on `http://localhost:3001`.
 
+## API endpoints
+
+While the UI is running, the Express server exposes a few helper endpoints:
+
+- `POST /api/pagesv2` – runs `tools/page-builder.v2.ts` to regenerate pages.
+- `GET /api/images?mod=<id>` – executes `tools/print-images.ts` and returns its
+  output.  Pass a `mod` query to limit the listing.
+- `POST /api/upload` – runs `tools/page-uploader.ts` for the provided `{ id }`
+  body.
+
+
 ## Mod loader docs
 
 - [Fabric development guide](https://docs.fabricmc.net/develop/)


### PR DESCRIPTION
## Summary
- call tool scripts from express API
- allow CORS from any origin
- document API endpoints

## Testing
- `npm --prefix ui run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e1c07807083318ae2a0bbfc2c1844