### PR TITLE
Refactor services into separate modules

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -9,7 +9,7 @@ import {
   validateMods as validateModsService,
   generateOtherMods,
   processScratchpad,
-} from './src/services/modTools';
+} from './src/services';
 
 const app = express();
 app.use(cors({ origin: '*' }));
@@ -122,4 +122,3 @@ app.post('/api/othermods', (_req, res) => {
 
 const port = process.env.PORT || 3001;
 app.listen(port, () => console.log(`API server running on ${port}`));
-

--- a/src/services/icons.ts
+++ b/src/services/icons.ts
@@ -1,0 +1,38 @@
+// Icon generation utilities.
+//
+// This module creates PNG icons by compositing multiple image layers as defined
+// in mods.v2.json.
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+import sharp from 'sharp';
+import { ModEntry, readMods } from '../../lib/readMods';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export async function generateIcons(): Promise<void> {
+  const modsJsonPath = path.join(ROOT, 'mods.v2.json');
+  const modsData: ModEntry[] = readMods(modsJsonPath);
+  const outputDir = path.join(ROOT, 'pages');
+  const outputFilePath = (id: string) => path.join(outputDir, id, 'icon.v2.png');
+
+  const generateIcon = async (filePaths: string[], id: string) => {
+    const images = filePaths.map((p) => sharp(path.join('tools/icon-parts', p)));
+    const { width, height } = await images[0].metadata();
+    const base = sharp({
+      create: { width: width!, height: height!, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } },
+    });
+    const composite = [] as { input: Buffer }[];
+    for (const img of images) composite.push({ input: await img.toBuffer() });
+    await base.composite(composite).png().toFile(outputFilePath(id));
+    console.log(chalk.green(`✅ Icon for ${id} generated successfully`));
+  };
+
+  const promises: Promise<void>[] = [];
+  for (const mod of modsData) {
+    if (mod.icon) promises.push(generateIcon(mod.icon, mod.id));
+  }
+  await Promise.all(promises);
+  console.log(chalk.green(`✅ Generated ${promises.length} icons successfully.`));
+}

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -1,0 +1,26 @@
+// Image listing helpers.
+//
+// Provides a simple function that returns GitHub URLs for PNG images stored in
+// the pages directory.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function listImages(mod?: string): Record<string, string[]> {
+  const githubBaseURL = 'https://raw.githubusercontent.com/iamkaf/modresources/refs/heads/main/pages';
+  const pagesDir = path.join(ROOT, 'pages');
+  const result: Record<string, string[]> = {};
+  const mods = mod ? [mod] : fs.readdirSync(pagesDir);
+  for (const m of mods) {
+    const dir = path.join(pagesDir, m);
+    if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) continue;
+    const images = fs.readdirSync(dir).filter((f) => f.endsWith('.png'));
+    if (images.length) {
+      result[m] = images.map((img) => `${githubBaseURL}/${m}/${img}`);
+    }
+  }
+  return result;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,8 @@
+// Central export file for service utilities.
+
+export * from './pages';
+export * from './icons';
+export * from './upload';
+export * from './images';
+export * from './validation';
+export * from './scratchpad';

--- a/src/services/scratchpad.ts
+++ b/src/services/scratchpad.ts
@@ -1,0 +1,18 @@
+// Scratchpad helpers.
+//
+// Converts scratchpad.md into a JSON-safe string and copies it to the clipboard.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import clipboardy from 'clipboardy';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function processScratchpad(): string {
+  const file = path.join(ROOT, 'tools', 'scratchpad.md');
+  const content = fs.readFileSync(file, 'utf-8');
+  const sanitized = content.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '');
+  clipboardy.writeSync(`"${sanitized}"`);
+  return sanitized;
+}

--- a/src/services/upload.ts
+++ b/src/services/upload.ts
@@ -1,0 +1,49 @@
+// Utilities for uploading generated README pages.
+//
+// The uploadPage function pushes the README to Modrinth and opens the
+// corresponding CurseForge project for manual updates.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+import clipboardy from 'clipboardy';
+import open from 'open';
+import { config } from 'dotenv';
+import { ModEntry, readMods } from '../../lib/readMods';
+
+config();
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export async function uploadPage(id: string): Promise<void> {
+  const modsPath = path.join(ROOT, 'mods.v2.json');
+  const mods: ModEntry[] = readMods(modsPath);
+  const mod = mods.find((m) => m.id === id);
+  if (!mod) throw new Error(`Mod ${id} not found`);
+  if (!mod.ids?.modrinth) throw new Error(`Mod ${id} does not have a Modrinth ID`);
+
+  const modPageMd = fs.readFileSync(path.join(ROOT, 'pages', mod.id, 'README.md'), 'utf-8');
+  const payload = { body: modPageMd + `\n\n---\n\n📃 ${new Date().toISOString()}` };
+
+  const apiKey = process.env.MODRINTH_API_KEY;
+  if (!apiKey) throw new Error('MODRINTH_API_KEY missing in env');
+
+  const response = await fetch(`https://api.modrinth.com/v2/project/${mod.ids.modrinth}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'User-Agent': "iamkaf's Modrinth Page Uploader (https://github.com/iamkaf/modresources)",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) throw new Error(`Failed to update project: ${response.statusText}`);
+
+  clipboardy.writeSync(modPageMd);
+  if (mod.ids?.curseforge) {
+    const url = `https://authors.curseforge.com/#/projects/${mod.ids.curseforge}/description`;
+    open(url);
+  }
+  console.log(chalk.green.bold(`✔ Successfully updated project ${mod.name}`));
+}

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -1,0 +1,80 @@
+// JSON validation utilities.
+//
+// validateMods ensures that mods.v2.json conforms to the expected schema and
+// reports any errors.
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Validator } from 'jsonschema';
+import { ModEntry, readMods } from '../../lib/readMods';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function validateMods(): string {
+  const modsPath = path.join(ROOT, 'mods.v2.json');
+  const mods: ModEntry[] = readMods(modsPath);
+  const schema = {
+    type: 'array',
+    items: {
+      type: 'object',
+      required: ['id', 'name', 'pages', 'dependencies'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        icon: { type: 'array', items: { type: 'string' } },
+        ids: {
+          type: 'object',
+          properties: {
+            modrinth: { type: 'string' },
+            curseforge: { type: 'string' },
+          },
+        },
+        urls: {
+          type: 'object',
+          properties: {
+            modrinth: { type: 'string' },
+            curseforge: { type: 'string' },
+            source: { type: 'string' },
+            issues: { type: 'string' },
+            support: { type: 'string' },
+            discord: { type: 'string' },
+          },
+        },
+        dependencies: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['name', 'loader', 'modrinthUrl', 'curseforgeUrl'],
+            properties: {
+              name: { type: 'string' },
+              loader: { enum: ['fabric', 'forge', 'neoforge', 'all'] },
+              modrinthUrl: { type: 'string' },
+              curseforgeUrl: { type: 'string' },
+              notes: { type: 'string' },
+            },
+          },
+        },
+        pages: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['title', 'level', 'content'],
+            properties: {
+              title: { type: 'string' },
+              level: { type: 'number' },
+              content: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const validator = new Validator();
+  const result = validator.validate(mods, schema);
+  if (result.valid) {
+    return `✔ mods.v2.json looks good (${mods.length} mods checked)`;
+  }
+  const lines = result.errors.map((e) => `✖ ${e.stack}`).join('\n');
+  return lines;
+}


### PR DESCRIPTION
## Summary
- extract each service into its own file under `src/services`
- add new `src/services/index.ts` to re-export all functions
- update `server.ts` to use the new entry point
- delete old `modTools.ts`

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685eff191f388331bb698ff974a32a04