### PR TITLE
Add Moddy registry generator and update handling

### DIFF
--- a/moddy/registry/0.2.0/moddy.py
+++ b/moddy/registry/0.2.0/moddy.py
@@ -37,7 +37,7 @@ from pathlib import Path
 AUTO_YES = False
 
 # Current Moddy version. Bump this when publishing updates.
-MODDY_VERSION = "DEVELOPMENT"
+MODDY_VERSION = "0.2.0"
 # URLs used by the ``update`` command.
 VERSION_REGISTRY_URL = (
     "https://raw.githubusercontent.com/iamkaf/modresources/main/moddy/versions.json"

--- a/moddy/versions.json
+++ b/moddy/versions.json
@@ -1,8 +1,18 @@
 [
   {
+    "version": "0.2.0",
+    "source": "/moddy/registry/0.2.0/moddy.py",
+    "notes": [
+      "Implemented a new registry system."
+    ],
+    "hash": "13438d4f72a7b0a5f877a45f2fc5d862380b49de60b28b462248a56e81c5ecc9"
+  },
+  {
     "version": "0.1.0",
     "source": "/moddy/registry/0.1.0/moddy.py",
-    "notes": ["The first version of Moddy!"],
+    "notes": [
+      "The first version of Moddy!"
+    ],
     "hash": "b6e5ececfd3e1a2c773527e0cb05eae0dc7e4b79a7760de323d79798f7a5baad"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.react.json",
     "preview": "vite preview",
     "generate:modrinth": "tsx ./scripts/generateModrinthClient.ts",
-    "generate:updates": "tsx ./scripts/generateForgeUpdates.ts"
+    "generate:updates": "tsx ./scripts/generateForgeUpdates.ts",
+    "generate:moddy": "tsx ./scripts/generateModdy.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/generateModdy.ts
+++ b/scripts/generateModdy.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env ts-node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import crypto from 'node:crypto';
+
+function usage() {
+  console.log('Usage: generateModdy.ts <patch|minor|major> [note]');
+  process.exit(1);
+}
+
+async function main() {
+  const [bump, ...noteParts] = process.argv.slice(2);
+  if (!bump || !['patch', 'minor', 'major'].includes(bump)) usage();
+  const note = noteParts.join(' ');
+
+  const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+  const devPath = path.join(root, 'moddy', 'development', 'moddy.py');
+  const versionsPath = path.join(root, 'moddy', 'versions.json');
+  const registryDir = path.join(root, 'moddy', 'registry');
+
+  const versions = JSON.parse(readFileSync(versionsPath, 'utf8')) as any[];
+  const latest = versions[0]?.version || '0.0.0';
+  let [maj, min, pat] = latest.split('.').map((v: string) => parseInt(v, 10));
+  if (bump === 'major') {
+    maj++; min = 0; pat = 0;
+  } else if (bump === 'minor') {
+    min++; pat = 0;
+  } else {
+    pat++;
+  }
+  const newVersion = `${maj}.${min}.${pat}`;
+
+  const outDir = path.join(registryDir, newVersion);
+  mkdirSync(outDir, { recursive: true });
+
+  const devCode = readFileSync(devPath, 'utf8');
+  const updatedCode = devCode.replace(
+    /MODDY_VERSION\s*=\s*"DEVELOPMENT"/,
+    `MODDY_VERSION = "${newVersion}"`
+  );
+  const outPath = path.join(outDir, 'moddy.py');
+  writeFileSync(outPath, updatedCode);
+
+  const hash = crypto.createHash('sha256').update(updatedCode).digest('hex');
+
+  const entry = {
+    version: newVersion,
+    source: `/moddy/registry/${newVersion}/moddy.py`,
+    notes: note ? [note] : [],
+    hash,
+  };
+  versions.unshift(entry);
+  writeFileSync(versionsPath, JSON.stringify(versions, null, 2) + '\n');
+
+  console.log(`Created ${path.relative(root, outPath)}`);
+  console.log(`Updated versions.json with ${newVersion}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `generateModdy.ts` script for publishing new Moddy versions
- store generated Moddy `0.2.0` in `moddy/registry`
- prepend entry for `0.2.0` in `versions.json`
- update `package.json` to expose `generate:moddy` command
- modify development `moddy.py` to read the registry JSON when updating

## Testing
- `npm test`
- `npm run generate:moddy -- minor "Implemented a new registry system."`


------
https://chatgpt.com/codex/tasks/task_e_68604625ac4c833187bb875945c082d8