### PR TITLE
Update Moddy setup and changelog

### DIFF
--- a/moddy/README.md
+++ b/moddy/README.md
@@ -1,0 +1,34 @@
+# Moddy 🤖
+
+Moddy is a small Python helper script for the [multiloader-template](https://github.com/iamkaf/multiloader-template). It bundles the setup and maintenance tools used when starting a new mod project.
+
+## Concept
+
+Instead of a collection of individual scripts, Moddy distributes a single self updating file. This keeps the template lightweight while still allowing improvements to be delivered quickly.
+
+## Problem it solves
+
+Setting up a new mod normally requires renaming packages and updating identifiers in several modules. Moddy automates these tasks through the `setup` command and offers other helpers such as self-update.
+
+## Changelog
+
+
+### 0.5.0
+- Clean up empty package folders in setup
+- Show changelog after update
+
+
+### 0.4.0
+- Fixed argument parsing in some commands.
+
+
+### 0.3.0
+- Improve update command message; improve help message.
+
+
+### 0.2.0
+- Implemented a new registry system.
+
+
+### 0.1.0
+- The first version of Moddy!

--- a/moddy/registry/0.5.0/moddy.py
+++ b/moddy/registry/0.5.0/moddy.py
@@ -39,7 +39,7 @@ from pathlib import Path
 AUTO_YES = False
 
 # Current Moddy version. Bump this when publishing updates.
-MODDY_VERSION = "DEVELOPMENT"
+MODDY_VERSION = "0.5.0"
 # URLs used by the ``update`` command.
 VERSION_REGISTRY_URL = (
     "https://raw.githubusercontent.com/iamkaf/modresources/main/moddy/versions.json"

--- a/moddy/versions.json
+++ b/moddy/versions.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "0.5.0",
+    "source": "/moddy/registry/0.5.0/moddy.py",
+    "notes": [
+      "Clean up empty package folders in setup",
+      "Show changelog after update"
+    ],
+    "hash": "c7ccfe4a60a3b06ed218cc4cebf3800aafe5fee00d56694ecefcd3aaad786d85"
+  },
+  {
     "version": "0.4.0",
     "source": "/moddy/registry/0.4.0/moddy.py",
     "notes": [

--- a/scripts/generateModdy.ts
+++ b/scripts/generateModdy.ts
@@ -61,6 +61,26 @@ async function main() {
   versions.unshift(entry);
   writeFileSync(versionsPath, JSON.stringify(versions, null, 2) + '\n');
 
+  const readmePath = path.join(root, 'moddy', 'README.md');
+  try {
+    const readme = readFileSync(readmePath, 'utf8');
+    const marker = '## Changelog';
+    const idx = readme.indexOf(marker);
+    if (idx !== -1) {
+      const head = readme.slice(0, idx + marker.length);
+      const body = versions
+        .map((v) => {
+          const notesList = v.notes?.map((n: string) => `- ${n}`).join('\n') || '';
+          return `\n\n### ${v.version}\n${notesList}`.trimEnd();
+        })
+        .join('\n');
+      writeFileSync(readmePath, `${head}\n${body}\n`);
+      console.log('Updated README changelog');
+    }
+  } catch (err) {
+    console.warn('Failed to update README:', err);
+  }
+
   console.log(`Created ${path.relative(root, outPath)}`);
   console.log(`Updated versions.json with ${newVersion}`);
 }


### PR DESCRIPTION
## Summary
- clean up empty package folders in `setup`
- show changelog notes when running `update`
- maintain README changelog when generating a release
- publish Moddy version 0.5.0
- fix changelog bullet formatting for 0.5.0

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(tests passed then process waited for file changes, canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68607d8a2a9c8331abbbb6694f4da55e