### PR TITLE
Handle game_versions update in Moddy

### DIFF
--- a/moddy/development/moddy.py
+++ b/moddy/development/moddy.py
@@ -320,7 +320,13 @@ def _apply_versions(props_path: Path, mc: str, versions: dict) -> None:
     for key, value in replacements.items():
         if not value:
             continue
-        text = re.sub(rf"(?m)^{re.escape(key)}=.*$", f"{key}={value}", text)
+        pattern = rf"(?m)^{re.escape(key)}=.*$"
+        if re.search(pattern, text):
+            text = re.sub(pattern, f"{key}={value}", text)
+        else:
+            if not text.endswith("\n"):
+                text += "\n"
+            text += f"{key}={value}\n"
     props_path.write_text(text, encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary
- ensure `set-minecraft-version` command updates the `game_versions` property

## Testing
- `python3 -m py_compile moddy/development/moddy.py`
- `python3 moddy/development/moddy.py help | head`
- `npm test >/tmp/npm_test.log && tail -n 20 /tmp/npm_test.log`

------
https://chatgpt.com/codex/tasks/task_e_6861523800488331b8a10157a5db0433