### PR TITLE
Prefix interface name in Moddy add-service

### DIFF
--- a/moddy/development/moddy.py
+++ b/moddy/development/moddy.py
@@ -67,11 +67,13 @@ def cmd_add_service(args: argparse.Namespace) -> None:
     if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
         raise SystemExit("Illegal characters in service name")
 
+    interface_name = f"I{name}"
+
     group = _parse_group(Path("gradle.properties"))
     pkg_path = group.replace(".", "/")
-    service_fqn = f"{group}.platform.services.{name}"
+    service_fqn = f"{group}.platform.services.{interface_name}"
 
-    interface_path = Path("common/src/main/java") / pkg_path / "platform" / "services" / f"{name}.java"
+    interface_path = Path("common/src/main/java") / pkg_path / "platform" / "services" / f"{interface_name}.java"
     fabric_impl_path = Path("fabric/src/main/java") / pkg_path / "platform" / f"Fabric{name}.java"
     forge_impl_path = Path("forge/src/main/java") / pkg_path / "platform" / f"Forge{name}.java"
     neo_impl_path = Path("neoforge/src/main/java") / pkg_path / "platform" / f"NeoForge{name}.java"
@@ -82,16 +84,16 @@ def cmd_add_service(args: argparse.Namespace) -> None:
 
     # Template contents for all generated files
     files = {
-        interface_path: f"package {group}.platform.services;\n\npublic interface {name} {{\n}}\n",
-        fabric_impl_path: f"package {group}.platform;\n\nimport {service_fqn};\n\npublic class Fabric{name} implements {name} {{\n}}\n",
-        forge_impl_path: f"package {group}.platform;\n\nimport {service_fqn};\n\npublic class Forge{name} implements {name} {{\n}}\n",
-        neo_impl_path: f"package {group}.platform;\n\nimport {service_fqn};\n\npublic class NeoForge{name} implements {name} {{\n}}\n",
+        interface_path: f"package {group}.platform.services;\n\npublic interface {interface_name} {{\n}}\n",
+        fabric_impl_path: f"package {group}.platform;\n\nimport {service_fqn};\n\npublic class Fabric{name} implements {interface_name} {{\n}}\n",
+        forge_impl_path: f"package {group}.platform;\n\nimport {service_fqn};\n\npublic class Forge{name} implements {interface_name} {{\n}}\n",
+        neo_impl_path: f"package {group}.platform;\n\nimport {service_fqn};\n\npublic class NeoForge{name} implements {interface_name} {{\n}}\n",
         fabric_meta: f"{group}.platform.Fabric{name}\n",
         forge_meta: f"{group}.platform.Forge{name}\n",
         neo_meta: f"{group}.platform.NeoForge{name}\n",
     }
 
-    print(f"This will create a new service called '{name}'.")
+    print(f"This will create a new service called '{interface_name}'.")
     print("The following files will be created:\n")
     for path, content in files.items():
         print(f"--- {path}")
@@ -113,6 +115,30 @@ def cmd_add_service(args: argparse.Namespace) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         print(f"Created {path}")
+
+    services_path = Path("common/src/main/java") / pkg_path / "platform" / "Services.java"
+    if services_path.exists():
+        text = services_path.read_text(encoding="utf-8")
+        import_line = f"import {service_fqn};"
+        if import_line not in text:
+            m = re.search(r"(package[^\n]+;\n)", text)
+            if m:
+                insert_pos = m.end()
+                text = text[:insert_pos] + import_line + "\n" + text[insert_pos:]
+            else:
+                text = import_line + "\n" + text
+        field_name = name[:1].lower() + name[1:]
+        field_line = f"    public static {interface_name} {field_name} = load({interface_name}.class);"
+        if field_line not in text:
+            idx = text.rfind("}")
+            if idx != -1:
+                text = text[:idx].rstrip() + "\n" + field_line + "\n}" + text[idx+1:]
+            else:
+                text += "\n" + field_line + "\n"
+        services_path.write_text(text, encoding="utf-8")
+        print(f"Updated {services_path}")
+    else:
+        print(f"Services class not found at {services_path}; skipping update.")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update `add-service` command in moddy development script so that service interfaces start with `I`
- register the new service in `Services.java`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686159c7e78883319ac52255fffa940d