### PR TITLE
Add changelog fetcher page and API

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -8,6 +8,7 @@ import {
   listImages,
   validateMods as validateModsService,
   generateOtherMods,
+  fetchChangelog,
 } from './src/services';
 
 const app = express();
@@ -58,6 +59,19 @@ app.get('/api/images', (req, res) => {
     const mod = req.query.mod as string | undefined;
     const data = listImages(mod);
     res.json(data);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/changelog/:loader/:id', async (req, res) => {
+  const { loader, id } = req.params as { loader: string; id: string };
+  if (!['fabric', 'forge', 'neoforge'].includes(loader)) {
+    return res.status(400).json({ error: 'invalid loader' });
+  }
+  try {
+    const text = await fetchChangelog(id, loader as any);
+    res.type('text').send(text);
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Upload from './pages/Upload';
 import Icon from './pages/Icon';
 import Validate from './pages/Validate';
 import Othermods from './pages/Othermods';
+import Changelog from './pages/Changelog';
 
 export default function App() {
   return (
@@ -20,6 +21,7 @@ export default function App() {
         <Route path="/icon" element={<Icon />} />
         <Route path="/validate" element={<Validate />} />
         <Route path="/othermods" element={<Othermods />} />
+        <Route path="/changelog" element={<Changelog />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -8,6 +8,7 @@ import {
   SparklesIcon,
   CheckCircleIcon,
   PuzzlePieceIcon,
+  DocumentMagnifyingGlassIcon,
   SwatchIcon,
   ChevronDownIcon,
   Cog6ToothIcon,
@@ -21,6 +22,7 @@ const pages = [
   { path: '/icon', label: 'icon', icon: SparklesIcon },
   { path: '/validate', label: 'validate', icon: CheckCircleIcon },
   { path: '/othermods', label: 'othermods', icon: PuzzlePieceIcon },
+  { path: '/changelog', label: 'changelog', icon: DocumentMagnifyingGlassIcon },
 ];
 
 const themes = [

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../api', () => ({
   validateMods: vi.fn(),
   generateOtherMods: vi.fn(),
   listImagesApi: () => Promise.resolve({}),
+  fetchChangelogApi: vi.fn(),
 }));
 
 test('renders navbar', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,3 +64,9 @@ export async function listImagesApi(mod?: string): Promise<Record<string, string
   return res.json();
 }
 
+export async function fetchChangelogApi(id: string, loader: string): Promise<string> {
+  const res = await fetch(`${BASE}/changelog/${loader}/${id}`);
+  if (!res.ok) throw new Error(res.statusText);
+  return res.text();
+}
+

--- a/src/pages/Changelog.tsx
+++ b/src/pages/Changelog.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import Layout from '../Layout';
+import { fetchChangelogApi } from '../api';
+
+export default function Changelog() {
+  const [loader, setLoader] = useState<'fabric' | 'neoforge' | 'forge'>('fabric');
+  const [id, setId] = useState('');
+  const [text, setText] = useState('');
+
+  const run = async () => {
+    try {
+      const result = await fetchChangelogApi(id, loader);
+      setText(result);
+    } catch {
+      setText('Failed to fetch changelog');
+    }
+  };
+
+  return (
+    <Layout title="Changelog">
+      <div className="space-y-2">
+        <select className="select" value={loader} onChange={(e) => setLoader(e.target.value as any)}>
+          <option value="fabric">Fabric</option>
+          <option value="neoforge">NeoForge</option>
+          <option value="forge">Forge</option>
+        </select>
+        <input className="input" value={id} onChange={(e) => setId(e.target.value)} placeholder="Modrinth ID" />
+        <button className="btn btn-primary" onClick={run} disabled={!id}>
+          Fetch Changelog
+        </button>
+        {text && <pre className="whitespace-pre-wrap bg-base-200 p-2 rounded">{text}</pre>}
+      </div>
+    </Layout>
+  );
+}

--- a/src/services/changelog.ts
+++ b/src/services/changelog.ts
@@ -1,0 +1,23 @@
+import chalk from 'chalk';
+
+export type Loader = 'fabric' | 'neoforge' | 'forge';
+
+/**
+ * Fetch the latest changelog for a project from Modrinth filtered by loader.
+ * @param modrinthId Modrinth project ID
+ * @param loader Desired mod loader
+ */
+export async function fetchChangelog(modrinthId: string, loader: Loader): Promise<string> {
+  const res = await fetch(`https://api.modrinth.com/v2/project/${modrinthId}/version`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch versions: ${res.status} ${res.statusText}`);
+  }
+  const versions = (await res.json()) as any[];
+  const version = versions.find((v) => Array.isArray(v.loaders) && v.loaders.includes(loader));
+  if (!version) {
+    throw new Error(`No ${loader} version found for ${modrinthId}`);
+  }
+  const changelog = version.changelog ?? '';
+  console.log(chalk.green(`✔ Fetched changelog for ${modrinthId} (${loader})`));
+  return changelog as string;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,3 +5,4 @@ export * from './icons';
 export * from './upload';
 export * from './images';
 export * from './validation';
+export * from './changelog';


### PR DESCRIPTION
## Summary
- add changelog fetcher service to query Modrinth
- expose new /api/changelog route in Express server
- hook fetcher in client api helpers
- create `Changelog` page and add it to the UI
- update navbar and routing
- adapt tests for new api mock

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(cancelled after run)*

------
https://chatgpt.com/codex/tasks/task_e_6861613b9d288331b11fe0a675d05990