### PR TITLE
Add changelog fetcher utility and page

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -8,6 +8,7 @@ import {
   listImages,
   validateMods as validateModsService,
   generateOtherMods,
+  fetchChangelog,
 } from './src/services';
 
 const app = express();
@@ -105,6 +106,16 @@ app.post('/api/othermods', (_req, res) => {
   try {
     generateOtherMods();
     res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/changelog/:loader', async (req, res) => {
+  const loader = req.params.loader as 'fabric' | 'neoforge' | 'forge';
+  try {
+    const text = await fetchChangelog(loader);
+    res.type('text').send(text);
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Upload from './pages/Upload';
 import Icon from './pages/Icon';
 import Validate from './pages/Validate';
 import Othermods from './pages/Othermods';
+import Changelog from './pages/Changelog';
 
 export default function App() {
   return (
@@ -20,6 +21,7 @@ export default function App() {
         <Route path="/icon" element={<Icon />} />
         <Route path="/validate" element={<Validate />} />
         <Route path="/othermods" element={<Othermods />} />
+        <Route path="/changelog" element={<Changelog />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -8,6 +8,7 @@ import {
   SparklesIcon,
   CheckCircleIcon,
   PuzzlePieceIcon,
+  DocumentTextIcon,
   SwatchIcon,
   ChevronDownIcon,
   Cog6ToothIcon,
@@ -21,6 +22,7 @@ const pages = [
   { path: '/icon', label: 'icon', icon: SparklesIcon },
   { path: '/validate', label: 'validate', icon: CheckCircleIcon },
   { path: '/othermods', label: 'othermods', icon: PuzzlePieceIcon },
+  { path: '/changelog', label: 'changelog', icon: DocumentTextIcon },
 ];
 
 const themes = [

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,3 +64,8 @@ export async function listImagesApi(mod?: string): Promise<Record<string, string
   return res.json();
 }
 
+export async function fetchChangelogApi(loader: 'fabric' | 'neoforge' | 'forge'): Promise<string> {
+  const res = await fetch(`${BASE}/changelog/${loader}`);
+  return res.text();
+}
+

--- a/src/pages/Changelog.tsx
+++ b/src/pages/Changelog.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import Layout from '../Layout';
+import { fetchChangelogApi } from '../api';
+
+export default function Changelog() {
+  const [loader, setLoader] = useState<'fabric' | 'neoforge' | 'forge'>('fabric');
+  const [output, setOutput] = useState('');
+
+  const run = async () => {
+    const text = await fetchChangelogApi(loader);
+    setOutput(text);
+  };
+
+  return (
+    <Layout title="Changelog">
+      <div className="space-y-2">
+        <select
+          className="select select-bordered"
+          value={loader}
+          onChange={(e) => setLoader(e.target.value as any)}
+        >
+          <option value="fabric">Fabric</option>
+          <option value="neoforge">NeoForge</option>
+          <option value="forge">Forge</option>
+        </select>
+        <button className="btn btn-primary" onClick={run}>
+          Fetch Changelog
+        </button>
+      </div>
+      {output && (
+        <pre className="whitespace-pre-wrap bg-base-200 p-2 rounded mt-2 overflow-x-auto">
+          {output}
+        </pre>
+      )}
+    </Layout>
+  );
+}

--- a/src/services/changelog.ts
+++ b/src/services/changelog.ts
@@ -1,0 +1,18 @@
+export async function fetchChangelog(loader: 'fabric' | 'neoforge' | 'forge'): Promise<string> {
+  const repos: Record<string, { owner: string; repo: string }> = {
+    fabric: { owner: 'FabricMC', repo: 'fabric-loader' },
+    neoforge: { owner: 'NeoForged', repo: 'NeoForge' },
+    forge: { owner: 'MinecraftForge', repo: 'MinecraftForge' },
+  };
+
+  const target = repos[loader];
+  if (!target) throw new Error(`Unsupported loader: ${loader}`);
+
+  const url = `https://api.github.com/repos/${target.owner}/${target.repo}/releases/latest`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    return `No changelog found for ${loader}`;
+  }
+  const data = (await res.json()) as { body?: string };
+  return data.body || `No changelog found for ${loader}`;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,3 +5,4 @@ export * from './icons';
 export * from './upload';
 export * from './images';
 export * from './validation';
+export * from './changelog';


### PR DESCRIPTION
## Summary
- introduce `fetchChangelog` service and API endpoint
- expose changelogs through `/api/changelog/:loader`
- add React page for fetching changelogs
- wire new page in router and navbar

## Testing
- `npm run lint`
- `npm run test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6861613b9d288331b11fe0a675d05990