### PR TITLE
Add open/docs commands

### DIFF
--- a/moddy/src/commands/__init__.py
+++ b/moddy/src/commands/__init__.py
@@ -1,5 +1,7 @@
 from .add_service import cmd_add_service
 from .open_libs import cmd_open_libs
+from .open import cmd_open
+from .docs import cmd_docs
 from .set_minecraft_version import cmd_set_minecraft_version
 from .setup_template import cmd_setup
 from .update import cmd_update
@@ -8,6 +10,8 @@ from .meta import cmd_help, cmd_version, check_for_update
 __all__ = [
     "cmd_add_service",
     "cmd_open_libs",
+    "cmd_open",
+    "cmd_docs",
     "cmd_set_minecraft_version",
     "cmd_setup",
     "cmd_update",

--- a/moddy/src/commands/docs.py
+++ b/moddy/src/commands/docs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import argparse
+
+from ..utils import open_url
+
+
+DOC_URLS = {
+    "fabric": "https://docs.fabricmc.net/develop/",
+    "neoforge": "https://docs.neoforged.net/docs/gettingstarted/",
+    "forge": "https://docs.minecraftforge.net/en/1.21.x/",
+    "parchment": "https://parchmentmc.org/docs/getting-started",
+    "linkie": "https://linkie.shedaniel.dev/mappings",
+}
+
+
+def cmd_docs(args: argparse.Namespace) -> None:
+    """Open the selected documentation page."""
+    url = DOC_URLS[args.target]
+    open_url(url)

--- a/moddy/src/commands/open.py
+++ b/moddy/src/commands/open.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from ..utils import open_url
+
+
+def cmd_open(args: argparse.Namespace) -> None:
+    """Open the mod page on the selected site."""
+    props_path = Path("gradle.properties")
+    mod_id = "examplemod"
+    author = "yourname"
+    if props_path.is_file():
+        text = props_path.read_text(encoding="utf-8")
+        m = re.search(r"^mod_id=(.+)$", text, re.MULTILINE)
+        if m:
+            mod_id = m.group(1).strip()
+        m = re.search(r"^mod_author=(.+)$", text, re.MULTILINE)
+        if m:
+            author = m.group(1).strip()
+
+    site = args.site
+    if site == "curseforge":
+        url = f"https://www.curseforge.com/minecraft/mc-mods/{mod_id}"
+    elif site == "modrinth":
+        url = f"https://modrinth.com/mod/{mod_id}"
+    else:  # github
+        url = f"https://github.com/{author}/{mod_id}"
+    open_url(url)

--- a/moddy/src/main.py
+++ b/moddy/src/main.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from .commands import (
     cmd_add_service,
     cmd_open_libs,
+    cmd_open,
+    cmd_docs,
     cmd_set_minecraft_version,
     cmd_setup,
     cmd_update,
@@ -27,6 +29,8 @@ from .commands import (
 COMMANDS = {
     "add-service": cmd_add_service,
     "open-libs": cmd_open_libs,
+    "open": cmd_open,
+    "docs": cmd_docs,
     "set-minecraft-version": cmd_set_minecraft_version,
     "setup": cmd_setup,
     "update": cmd_update,
@@ -72,6 +76,18 @@ def main(argv=None) -> None:
     elif func is cmd_open_libs:
         subparser.add_argument(
             "loader", choices=["fabric", "forge", "neoforge"], help="Loader to open the output for"
+        )
+    elif func is cmd_open:
+        subparser.add_argument(
+            "site",
+            choices=["curseforge", "modrinth", "github"],
+            help="Site to open",
+        )
+    elif func is cmd_docs:
+        subparser.add_argument(
+            "target",
+            choices=["fabric", "neoforge", "forge", "parchment", "linkie"],
+            help="Documentation site to open",
         )
     elif func is cmd_set_minecraft_version:
         subparser.add_argument("version", help="Minecraft version, e.g. 1.21.5")

--- a/moddy/src/utils.py
+++ b/moddy/src/utils.py
@@ -26,6 +26,17 @@ def open_dir(path: Path) -> None:
         subprocess.run(["xdg-open", str(path)], check=False)
 
 
+def open_url(url: str) -> None:
+    """Open *url* in the default browser."""
+    system = platform.system()
+    if system == "Windows":
+        os.startfile(url)  # type: ignore[attr-defined]
+    elif system == "Darwin":
+        subprocess.run(["open", url], check=False)
+    else:
+        subprocess.run(["xdg-open", url], check=False)
+
+
 def fetch_url_text(url: str, headers=None) -> str:
     req = urllib.request.Request(url, headers=headers or {})
     with urllib.request.urlopen(req) as resp:


### PR DESCRIPTION
## Summary
- add `open` command to open mod pages on chosen site
- add `docs` command to open documentation sites
- support opening URLs in utils
- include new commands in CLI and update registry
- **revert README and registry entry for unreleased 0.7.1**

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6862aed92b888331aad149c804b939f4