### PR TITLE
Add changelog command to Moddy

### DIFF
--- a/moddy/README.md
+++ b/moddy/README.md
@@ -9,6 +9,7 @@ Instead of a collection of individual scripts, Moddy distributes a single self u
 ## Problem it solves
 
 Setting up a new mod normally requires renaming packages and updating identifiers in several modules. Moddy automates these tasks through the `setup` command and offers other helpers such as self-update.
+The `changelog` command can be used to view notes for recent Moddy releases.
 
 ## Changelog
 

--- a/moddy/src/commands/__init__.py
+++ b/moddy/src/commands/__init__.py
@@ -6,6 +6,7 @@ from .set_minecraft_version import cmd_set_minecraft_version
 from .setup_template import cmd_setup
 from .update import cmd_update
 from .ping import cmd_ping
+from .changelog import cmd_changelog
 from .meta import cmd_help, cmd_version, check_for_update
 
 __all__ = [
@@ -17,6 +18,7 @@ __all__ = [
     "cmd_setup",
     "cmd_update",
     "cmd_ping",
+    "cmd_changelog",
     "cmd_help",
     "cmd_version",
     "check_for_update",

--- a/moddy/src/commands/changelog.py
+++ b/moddy/src/commands/changelog.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from ..utils import fetch_url_text
+from .. import VERSION_REGISTRY_URL
+
+
+def cmd_changelog(args: argparse.Namespace) -> None:
+    """Print the changelog for the last 3 Moddy versions."""
+    try:
+        registry = json.loads(fetch_url_text(VERSION_REGISTRY_URL))
+    except Exception as e:
+        print(f"Failed to fetch changelog: {e}")
+        return
+
+    for entry in registry[:3]:
+        version = entry.get("version", "unknown")
+        print(f"Version {version}:")
+        notes = entry.get("notes", [])
+        for note in notes:
+            print(f" - {note}")
+        print()

--- a/moddy/src/main.py
+++ b/moddy/src/main.py
@@ -21,6 +21,7 @@ from .commands import (
     cmd_setup,
     cmd_update,
     cmd_ping,
+    cmd_changelog,
     cmd_help,
     cmd_version,
     check_for_update,
@@ -36,6 +37,7 @@ COMMANDS = {
     "setup": cmd_setup,
     "update": cmd_update,
     "ping": cmd_ping,
+    "changelog": cmd_changelog,
     "help": cmd_help,
     "version": cmd_version,
 }


### PR DESCRIPTION
## Summary
- implement `changelog` command
- expose `cmd_changelog` through the commands package and CLI
- document changelog command in Moddy README

## Testing
- `python -m py_compile moddy/src/**/*.py`
- `npm run lint`
- `npm run test` *(cancelled watch mode after run)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6862bb32ff688331b5143703daefdf1b