### PR TITLE
Add version option to moddy update command

### DIFF
--- a/moddy/src/commands/update.py
+++ b/moddy/src/commands/update.py
@@ -17,7 +17,7 @@ from .. import AUTO_YES, MODDY_VERSION, VERSION_REGISTRY_URL, RAW_BASE_URL
 
 
 def cmd_update(args: argparse.Namespace) -> None:
-    """Download the latest version of Moddy and replace this file."""
+    """Download a specific Moddy version and replace this file."""
     print(
         "! ! ! WARNING ! ! !: Executing this command will fetch Python "
         "code from the internet and run it on your computer."
@@ -32,11 +32,24 @@ def cmd_update(args: argparse.Namespace) -> None:
     )
     try:
         registry = json.loads(fetch_url_text(VERSION_REGISTRY_URL))
-        latest = registry[0]
-        update_url = RAW_BASE_URL + latest.get("source", "")
     except Exception as e:
         print(f"Failed to check for updates: {e}")
         return
+
+    target_version = getattr(args, "version", None)
+    entry = None
+    if target_version:
+        for item in registry:
+            if item.get("version") == target_version:
+                entry = item
+                break
+        if not entry:
+            print(f"Version {target_version} not found in registry")
+            return
+    else:
+        entry = registry[0]
+
+    update_url = RAW_BASE_URL + entry.get("source", "")
 
     print(f"Registry: {VERSION_REGISTRY_URL}")
     print(f"Source: {update_url}")
@@ -107,7 +120,7 @@ def cmd_update(args: argparse.Namespace) -> None:
         return
     print(f"Updated Moddy from {MODDY_VERSION} to {new_version}")
     print(f"A backup of the previous version was saved to {backup}")
-    notes = latest.get("notes", []) if isinstance(latest, dict) else []
+    notes = entry.get("notes", []) if isinstance(entry, dict) else []
     if notes:
         print(f"Changelog for {new_version}:")
         for n in notes:

--- a/moddy/src/main.py
+++ b/moddy/src/main.py
@@ -95,6 +95,12 @@ def main(argv=None) -> None:
         )
     elif func is cmd_set_minecraft_version:
         subparser.add_argument("version", help="Minecraft version, e.g. 1.21.5")
+    elif func is cmd_update:
+        subparser.add_argument(
+            "version",
+            nargs="?",
+            help="Moddy version to install (defaults to latest)",
+        )
 
     args = subparser.parse_args(ns.args)
     if func is cmd_help:


### PR DESCRIPTION
## Summary
- allow passing an optional version to `moddy update`
- show changelog for the selected version

## Testing
- `python -m py_compile moddy/src/commands/update.py moddy/src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6862dd247d8483319544dd1c0e112ddd