### PR TITLE
Refactor mod page editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ All helper utilities are now exposed through a small Express API that powers the
 - `docs` 📚 - Extra markdown notes.
 - `scripts` 📜 - Standalone helper scripts.
 - `src/utils` 🧩 - Reusable TypeScript utilities.
+- Each mod entry now stores a full `readme` string compiled with
+  [Handlebars](https://handlebarsjs.com). Use any field from the mod entry in
+  `{{doubleCurlyBraces}}`.
+- Common templates live under `pages/common` and can be inserted in the UI
+  editor.
 
 ## Scripts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.0.0",
         "express": "^5.1.0",
+        "handlebars": "^4.7.8",
         "jsonschema": "^1.5.0",
         "node-emoji": "^2.2.0",
         "open": "^10.1.2",
@@ -7037,7 +7038,6 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -9058,7 +9058,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9148,7 +9147,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/next-tick": {
@@ -10414,7 +10412,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11017,7 +11014,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -11582,7 +11578,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
-    "sharp": "^0.34.2"
+    "sharp": "^0.34.2",
+    "handlebars": "^4.7.8"
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -9,6 +9,8 @@ import {
   validateMods as validateModsService,
   generateOtherMods,
   fetchChangelog,
+  listTemplates,
+  readTemplate,
 } from './src/services';
 
 const app = express();
@@ -61,6 +63,19 @@ app.get('/api/images', (req, res) => {
     res.json(data);
   } catch (err: any) {
     res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/templates', (_req, res) => {
+  res.json(listTemplates());
+});
+
+app.get('/api/templates/:name', (req, res) => {
+  try {
+    const text = readTemplate(req.params.name);
+    res.type('text').send(text);
+  } catch (err: any) {
+    res.status(404).json({ error: err.message });
   }
 });
 

--- a/src/ModManager.ts
+++ b/src/ModManager.ts
@@ -10,7 +10,7 @@
  *   manager.add({
  *     id: 'my-mod',
  *     name: 'My Mod',
- *     pages: [{ title: 'header', level: 1, content: 'My description' }]
+ *     readme: '# My Mod\nThis is my mod.'
  *   });
  */
 import fs from 'fs';

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -13,6 +13,8 @@ vi.mock('../api', () => ({
   validateMods: vi.fn(),
   generateOtherMods: vi.fn(),
   listImagesApi: () => Promise.resolve({}),
+  listTemplatesApi: () => Promise.resolve([]),
+  fetchTemplateApi: () => Promise.resolve(''),
 }));
 
 test('renders navbar', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,6 +64,16 @@ export async function listImagesApi(mod?: string): Promise<Record<string, string
   return res.json();
 }
 
+export async function listTemplatesApi(): Promise<string[]> {
+  const res = await fetch(`${BASE}/templates`);
+  return res.json();
+}
+
+export async function fetchTemplateApi(name: string): Promise<string> {
+  const res = await fetch(`${BASE}/templates/${name}`);
+  return res.text();
+}
+
 export async function fetchChangelogApi(loader: 'fabric' | 'neoforge' | 'forge'): Promise<string> {
   const res = await fetch(`${BASE}/changelog/${loader}`);
   return res.text();

--- a/src/pages/Mods.tsx
+++ b/src/pages/Mods.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { PencilSquareIcon, XMarkIcon, TrashIcon, CubeIcon, FireIcon, CommandLineIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
+import { PencilSquareIcon, XMarkIcon, TrashIcon, CubeIcon, FireIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
 import ModForm from '../ModForm';
 import Layout from '../Layout';
 import type { ModEntry } from '../utils/readMods';

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -18,7 +18,7 @@ export function validateMods(): string {
     type: 'array',
     items: {
       type: 'object',
-      required: ['id', 'name', 'pages', 'dependencies'],
+      required: ['id', 'name', 'dependencies'],
       properties: {
         id: { type: 'string' },
         name: { type: 'string' },
@@ -55,6 +55,7 @@ export function validateMods(): string {
             },
           },
         },
+        readme: { type: 'string' },
         pages: {
           type: 'array',
           items: {

--- a/src/utils/readMods.ts
+++ b/src/utils/readMods.ts
@@ -38,8 +38,11 @@ export interface ModEntry {
     support?: string;
     discord?: string;
   };
+  /** Markdown README content with {{placeholders}} */
+  readme?: string;
+  /** Legacy support for mods still using page sections */
+  pages?: PageSection[];
   dependencies: Dependency[];
-  pages: PageSection[];
 }
 
 export type ModsData = ModEntry[];


### PR DESCRIPTION
## Summary
- switch ModForm to a single README editor
- add replacement handling in page generator
- adapt ModEntry and validation schema for `readme`
- update ModManager example and docs
- handlebars replacements and template insertion support

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686634189ce88331877207ec6635cebf