### PR TITLE
Fix Moddy helper issues

### DIFF
--- a/moddy/src/commands/add_service.py
+++ b/moddy/src/commands/add_service.py
@@ -72,8 +72,10 @@ def cmd_add_service(args: argparse.Namespace) -> None:
                 text = text[:insert_pos] + import_line + "\n" + text[insert_pos:]
             else:
                 text = import_line + "\n" + text
-        field_name = name[:1].lower() + name[1:]
-        field_line = f"    public static {interface_name} {field_name} = load({interface_name}.class);"
+        const_name = re.sub(r"(?<!^)(?=[A-Z])", "_", name).upper()
+        field_line = (
+            f"    public static final {interface_name} {const_name} = load({interface_name}.class);"
+        )
         if field_line not in text:
             idx = text.rfind("}")
             if idx != -1:

--- a/moddy/src/commands/meta.py
+++ b/moddy/src/commands/meta.py
@@ -14,7 +14,8 @@ def cmd_help(args: argparse.Namespace, parser, commands) -> None:
     for name, func in commands.items():
         if func is cmd_help:
             continue
-        doc = (func.__doc__ or "").strip().splitlines()[0]
+        lines = (func.__doc__ or "").strip().splitlines()
+        doc = lines[0] if lines else ""
         logger.info(f"  {name:<22} {doc}")
 
 

--- a/moddy/src/commands/set_minecraft_version.py
+++ b/moddy/src/commands/set_minecraft_version.py
@@ -73,7 +73,7 @@ def _get_parchment_version(mc: str):
     while current:
         version = _fetch_parchment_version(current)
         if version:
-            return version
+            return current, version
         parts = current.split(".")
         if len(parts) < 3 or not parts[2].isdigit():
             break
@@ -82,7 +82,7 @@ def _get_parchment_version(mc: str):
             break
         parts[2] = str(patch)
         current = ".".join(parts)
-    return None
+    return None, None
 
 
 def _get_fabric_loader_version(mc: str):
@@ -146,12 +146,9 @@ def _get_forge_version(mc: str):
 
 
 def _collect_versions(mc: str, include_amber: bool = False) -> dict:
-    parchment_version = _get_parchment_version(mc)
-    parchment_mc = mc
-    if parchment_version:
-        m = re.match(r"([0-9]+(?:\.[0-9]+){1,2})-", parchment_version)
-        if m:
-            parchment_mc = m.group(1)
+    parchment_mc, parchment_version = _get_parchment_version(mc)
+    if not parchment_mc:
+        parchment_mc = mc
 
     versions = {
         "neoform_version": _get_neoform_version(mc),
@@ -197,7 +194,7 @@ def _apply_versions(props_path: Path, mc: str, versions: dict) -> None:
     for key, value in replacements.items():
         if not value:
             continue
-        pattern = rf"(?m)^{re.escape(key)}=.*$"
+        pattern = rf"(?m)^{re.escape(key)}\s*=.*$"
         if re.search(pattern, text):
             text = re.sub(pattern, f"{key}={value}", text)
         else:


### PR DESCRIPTION
## Summary
- improve help command when commands lack docstrings
- use constant style when injecting new services
- avoid duplicating `game_versions` in gradle.properties
- keep parchment minecraft version consistent with fetched XML

## Testing
- `python3 -m py_compile moddy/src/commands/meta.py moddy/src/commands/add_service.py moddy/src/commands/set_minecraft_version.py`
- `PYTHONPATH=. python -m moddy.src.main help`
- `python - <<'PY'
from moddy.src.commands.set_minecraft_version import _apply_versions
from pathlib import Path

p=Path('/tmp/gradle.properties');p.write_text('game_versions = 1.21.0\n')
_apply_versions(p,'1.21.5',{'fabric_loader_version':'0'});print(p.read_text())
PY`

------
https://chatgpt.com/codex/tasks/task_e_686761d0c9748331bfd27ec5b5228846